### PR TITLE
Configure volume mount for node_modules in devcontainer

### DIFF
--- a/devcontainer-hugo-bun/.devcontainer/devcontainer.json
+++ b/devcontainer-hugo-bun/.devcontainer/devcontainer.json
@@ -6,6 +6,10 @@
   "runArgs": [
     "--hostname=devcontainer-name"
   ],
+  // Keep node_modules out of a host machine
+  "mounts": [
+    "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+  ],
 
   // Configure tool-specific properties.
   "customizations": {


### PR DESCRIPTION
Added a volume mount for node_modules to the devcontainer configuration to isolate dependencies.