### PR TITLE
fix(ci): grant packages:write permission to reusable workflow callers

### DIFF
--- a/.github/workflows/build-devcontainer-bun.yml
+++ b/.github/workflows/build-devcontainer-bun.yml
@@ -31,6 +31,9 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       image-name: devcontainer-bun

--- a/.github/workflows/build-devcontainer-claude-bun.yml
+++ b/.github/workflows/build-devcontainer-claude-bun.yml
@@ -32,6 +32,9 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       image-name: devcontainer-claude-bun

--- a/.github/workflows/build-devcontainer-hugo-bun-node.yml
+++ b/.github/workflows/build-devcontainer-hugo-bun-node.yml
@@ -33,6 +33,9 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       image-name: devcontainer-hugo-bun-node

--- a/.github/workflows/build-devcontainer-hugo-bun.yml
+++ b/.github/workflows/build-devcontainer-hugo-bun.yml
@@ -32,6 +32,9 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       image-name: devcontainer-hugo-bun

--- a/.github/workflows/build-ralphex-fe.yml
+++ b/.github/workflows/build-ralphex-fe.yml
@@ -47,6 +47,9 @@ jobs:
 
   build:
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/reusable-docker-build.yml
     with:
       image-name: ralphex-fe

--- a/.github/workflows/update-and-build-ralphex-fe.yml
+++ b/.github/workflows/update-and-build-ralphex-fe.yml
@@ -142,6 +142,9 @@ jobs:
 
   build-and-push:
     needs: update-dockerfile
+    permissions:
+      contents: read
+      packages: write
     # Build if versions changed and update_only is not checked
     if: ${{ needs.update-dockerfile.outputs.versions_updated == 'true' && inputs.update_only == false }}
     uses: ./.github/workflows/reusable-docker-build.yml


### PR DESCRIPTION
The reusable workflow needs packages:write to push images to GHCR, but caller jobs weren't granting it — causing failures when repo default token permissions are read-only.