### PR TITLE
fix: upgrade Playwright to 1.58.2 for Debian Trixie support

### DIFF
--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@
 FROM node:22-trixie-slim AS base
 
 ARG GIT_DELTA_VERSION=0.18.2
-ARG PLAYWRIGHT_VERSION=1.50.1
+ARG PLAYWRIGHT_VERSION=1.58.2
 ARG AGENT_BROWSER_VERSION=0.14.0
 
 # System packages shared by all targets


### PR DESCRIPTION
Playwright 1.50.1 doesn't recognize Debian Trixie (13), falls back to Ubuntu 20.04 package list with legacy font names (ttf-unifont, ttf-ubuntu-font-family) that don't exist in Trixie.