### PR TITLE
feat(ci): smart cache busting for daily rebuilds

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 11 * * *'
   workflow_dispatch:
+    inputs:
+      no-cache:
+        description: 'Full rebuild without Docker cache'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -76,7 +81,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          no-cache: ${{ github.event_name != 'push' }}
+          build-args: |
+            CACHE_BUST=${{ github.event_name != 'push' && github.run_id || 'stable' }}
+          no-cache: ${{ inputs.no-cache == true }}
           cache-from: type=gha,scope=${{ matrix.target }}
           cache-to: type=gha,mode=max,scope=${{ matrix.target }}
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains Dockerfiles for custom Docker images hosted on GitHub C
 
 ### Devcontainer Images
 
+- **[claude-code](./claude-code/README.md)** - Shared Claude Code devcontainer image (default + sandbox variants)
 - **[devcontainer-bun](./devcontainer-bun/README.md)** - Bun development container
 - **[devcontainer-claude-bun](./devcontainer-claude-bun/README.md)** - Claude Code development container with firewall sandbox
 - **[devcontainer-hugo-bun](./devcontainer-hugo-bun/README.md)** - Hugo Extended + Bun development container
@@ -35,6 +36,27 @@ image-name/
 ```
 
 ## Available Images
+
+### claude-code
+
+Shared devcontainer base image for Claude Code projects. Two variants from a single multi-stage Dockerfile: **default** (full dev environment with agent-browser) and **sandbox** (network-restricted with iptables firewall). Projects consume pre-built images and control tool versions via `.mise.toml`. Rebuilds daily to pick up latest Claude Code.
+
+**Usage in other projects:**
+
+```jsonc
+// Default variant
+{
+  "image": "ghcr.io/gatezh/devcontainer-images/claude-code:latest"
+}
+
+// Sandbox variant
+{
+  "image": "ghcr.io/gatezh/devcontainer-images/claude-code-sandbox:latest",
+  "capAdd": ["NET_ADMIN", "NET_RAW"]
+}
+```
+
+See the [claude-code README](./claude-code/README.md) for full setup guide.
 
 ### devcontainer-bun
 

--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -16,7 +16,6 @@ FROM node:22-trixie-slim AS base
 
 ARG GIT_DELTA_VERSION=0.18.2
 ARG PLAYWRIGHT_VERSION=1.58.2
-ARG AGENT_BROWSER_VERSION=0.14.0
 
 # System packages shared by all targets
 # - ca-certificates: SSL/TLS for HTTPS connections
@@ -120,6 +119,12 @@ RUN npx -y playwright@${PLAYWRIGHT_VERSION} install-deps chromium
 USER node
 RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --only-shell
 
+# ── Cache bust ────────────────────────────────────────────────────────────────
+# Layers above (system packages, Playwright, etc.) stay cached for speed.
+# Layers below (Claude Code, agent-browser) rebuild when CACHE_BUST changes,
+# picking up the latest versions on daily scheduled builds.
+ARG CACHE_BUST=stable
+
 # ── Claude Code CLI (native installer) ───────────────────────────────────────
 # Native installer replaces deprecated npm method (npm install -g @anthropic-ai/claude-code)
 # See: https://code.claude.com/docs/en/getting-started
@@ -151,6 +156,7 @@ USER node
 # agent-browser: headless browser automation for AI agents
 # Installs its own bundled playwright-core + full chromium (separate from Playwright above)
 # Requires root for system deps (apt-get install triggered by --with-deps)
+ARG AGENT_BROWSER_VERSION=latest
 USER root
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
   && $(npm root -g)/agent-browser/node_modules/.bin/playwright-core install --with-deps chromium \

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -40,7 +40,7 @@ Both variants are built for:
 
 ## Automatic Rebuilds
 
-The image rebuilds daily at 5am MT (11:00 UTC) with no Docker cache, picking up the latest Claude Code, Playwright, and other tools. Manual rebuilds can be triggered via the "Run workflow" button in the Actions UI.
+The image rebuilds daily at 5am MT (11:00 UTC). Cached layers (system packages, Playwright) are reused for speed, while Claude Code and agent-browser always install fresh via a cache-busting build arg. Manual rebuilds can be triggered via the "Run workflow" button in the Actions UI.
 
 ## Quick Start
 
@@ -225,7 +225,7 @@ The image bakes in a Playwright browser binary at a specific version (controlled
 |-----|---------|-------------|
 | `GIT_DELTA_VERSION` | `0.18.2` | git-delta version |
 | `PLAYWRIGHT_VERSION` | `1.58.2` | Playwright browser binary version |
-| `AGENT_BROWSER_VERSION` | `0.14.0` | agent-browser version (default target only) |
+| `AGENT_BROWSER_VERSION` | `latest` | agent-browser version (default target only) |
 
 ## Building Locally
 


### PR DESCRIPTION
- Add CACHE_BUST build arg before Claude Code install — layers above (system packages, Playwright) stay cached, layers below (Claude Code, agent-browser) rebuild fresh on schedule/dispatch
- Move AGENT_BROWSER_VERSION to default stage, default to latest
- Add no-cache checkbox to workflow_dispatch UI
- Add claude-code to main README
- Update claude-code README with rebuild docs and version changes