### PR TITLE
feat(ci): smart cache busting for daily rebuilds

### DIFF
--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -154,12 +154,12 @@ RUN echo "node ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/node-nopasswd \
 USER node
 
 # agent-browser: headless browser automation for AI agents
-# Installs its own bundled playwright-core + full chromium (separate from Playwright above)
-# Requires root for system deps (apt-get install triggered by --with-deps)
+# Downloads Chrome from Chrome for Testing (Google's official automation channel).
+# --with-deps installs system dependencies on Linux.
 ARG AGENT_BROWSER_VERSION=latest
 USER root
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
-  && $(npm root -g)/agent-browser/node_modules/.bin/playwright-core install --with-deps chromium \
+  && agent-browser install --with-deps \
   && chown -R node:node /usr/local/share/npm-global
 USER node
 


### PR DESCRIPTION
- Add CACHE_BUST build arg before Claude Code install — layers above (system packages, Playwright) stay cached, layers below (Claude Code, agent-browser) rebuild fresh on schedule/dispatch
- Move AGENT_BROWSER_VERSION to default stage, default to latest
- Add no-cache checkbox to workflow_dispatch UI
- Add claude-code to main README
- Update claude-code README with rebuild docs and version changes