### PR TITLE
feat(ci): use docker/github-builder with native ARM runners

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -8,98 +8,98 @@ on:
   schedule:
     - cron: '0 11 * * *'
   workflow_dispatch:
-    inputs:
-      no-cache:
-        description: 'Full rebuild without Docker cache'
-        type: boolean
-        default: false
 
 permissions:
   contents: read
   packages: write
-  attestations: write
   id-token: write
-
-env:
-  REGISTRY: ghcr.io
 
 concurrency:
   group: build-claude-code-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    name: Build & Push (${{ matrix.target }})
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - target: default
-            image-suffix: claude-code
-            verify-command: "bun --version || true && claude --version && mise --version && fish --version"
-          - target: sandbox
-            image-suffix: claude-code-sandbox
-            verify-command: "claude --version && mise --version && fish --version && which iptables"
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Lowercase image base
-        id: repo
-        run: echo "image_base=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
+  build-default:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      output: image
+      push: true
+      target: default
+      context: claude-code/.devcontainer
+      file: claude-code/.devcontainer/Dockerfile
+      platforms: linux/amd64,linux/arm64
+      meta-images: ghcr.io/gatezh/devcontainer-images/claude-code
+      meta-tags: |
+        type=raw,value=latest
+        type=sha,prefix=
+        type=raw,value={{date 'YYYYMMDD'}}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ steps.repo.outputs.image_base }}/${{ matrix.image-suffix }}
-          tags: |
-            type=raw,value=latest
-            type=sha,prefix=
-            type=raw,value={{date 'YYYYMMDD'}}
+  build-sandbox:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      output: image
+      push: true
+      target: sandbox
+      context: claude-code/.devcontainer
+      file: claude-code/.devcontainer/Dockerfile
+      platforms: linux/amd64,linux/arm64
+      meta-images: ghcr.io/gatezh/devcontainer-images/claude-code-sandbox
+      meta-tags: |
+        type=raw,value=latest
+        type=sha,prefix=
+        type=raw,value={{date 'YYYYMMDD'}}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        id: push
-        uses: docker/build-push-action@v7
+  verify:
+    name: Verify ${{ matrix.image-suffix }} (${{ matrix.arch }})
+    needs: [build-default, build-sandbox]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image-suffix: claude-code
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version"
+            runner: ubuntu-24.04
+            arch: amd64
+          - image-suffix: claude-code
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version"
+            runner: ubuntu-24.04-arm
+            arch: arm64
+          - image-suffix: claude-code-sandbox
+            verify-command: "claude --version && mise --version && fish --version && which iptables"
+            runner: ubuntu-24.04
+            arch: amd64
+          - image-suffix: claude-code-sandbox
+            verify-command: "claude --version && mise --version && fish --version && which iptables"
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
         with:
-          context: claude-code/.devcontainer
-          file: claude-code/.devcontainer/Dockerfile
-          target: ${{ matrix.target }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            CACHE_BUST=${{ github.event_name != 'push' && github.run_id || 'stable' }}
-          no-cache: ${{ inputs.no-cache == true }}
-          cache-from: type=gha,scope=${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate artifact attestation
-        uses: actions/attest@v4
-        with:
-          subject-name: ${{ steps.repo.outputs.image_base }}/${{ matrix.image-suffix }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-
-      - name: Verify image (amd64)
+      - name: Verify image
         run: |
-          docker pull --platform linux/amd64 ${{ steps.repo.outputs.image_base }}/${{ matrix.image-suffix }}:latest
-          docker run --rm --platform linux/amd64 ${{ steps.repo.outputs.image_base }}/${{ matrix.image-suffix }}:latest bash -c "${{ matrix.verify-command }}"
-
-      - name: Verify image (arm64)
-        run: |
-          docker pull --platform linux/arm64 ${{ steps.repo.outputs.image_base }}/${{ matrix.image-suffix }}:latest
-          docker run --rm --platform linux/arm64 ${{ steps.repo.outputs.image_base }}/${{ matrix.image-suffix }}:latest bash -c "${{ matrix.verify-command }}"
+          docker pull ghcr.io/gatezh/devcontainer-images/${{ matrix.image-suffix }}:latest
+          docker run --rm ghcr.io/gatezh/devcontainer-images/${{ matrix.image-suffix }}:latest bash -c "${{ matrix.verify-command }}"

--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -119,12 +119,6 @@ RUN npx -y playwright@${PLAYWRIGHT_VERSION} install-deps chromium
 USER node
 RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --only-shell
 
-# ── Cache bust ────────────────────────────────────────────────────────────────
-# Layers above (system packages, Playwright, etc.) stay cached for speed.
-# Layers below (Claude Code, agent-browser) rebuild when CACHE_BUST changes,
-# picking up the latest versions on daily scheduled builds.
-ARG CACHE_BUST=stable
-
 # ── Claude Code CLI (native installer) ───────────────────────────────────────
 # Native installer replaces deprecated npm method (npm install -g @anthropic-ai/claude-code)
 # See: https://code.claude.com/docs/en/getting-started

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -40,7 +40,7 @@ Both variants are built for:
 
 ## Automatic Rebuilds
 
-The image rebuilds daily at 5am MT (11:00 UTC). Cached layers (system packages, Playwright) are reused for speed, while Claude Code and agent-browser always install fresh via a cache-busting build arg. Manual rebuilds can be triggered via the "Run workflow" button in the Actions UI.
+The image rebuilds daily at 5am MT (11:00 UTC) using native runners for both amd64 and arm64 (no QEMU emulation). Each rebuild picks up the latest Claude Code and agent-browser. Manual rebuilds can be triggered via the "Run workflow" button in the Actions UI.
 
 ## Quick Start
 


### PR DESCRIPTION
Replace QEMU emulation with native amd64/arm64 runners via Docker's reusable build workflow. Builds distribute across native runners automatically, eliminating the QEMU bottleneck.

- Switch to docker/github-builder/.github/workflows/build.yml@v1
- Remove QEMU setup, manual Buildx config, cache busting ARG
- Add native verify jobs on ubuntu-24.04 and ubuntu-24.04-arm
- Update README with native runner details