### PR TITLE
fix: retry Claude Code install on 429 + drop explicit file input

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -30,7 +30,7 @@ jobs:
       push: true
       target: default
       context: claude-code/.devcontainer
-      file: Dockerfile
+
       platforms: linux/amd64,linux/arm64
       meta-images: ghcr.io/gatezh/devcontainer-images/claude-code
       meta-tags: |
@@ -54,7 +54,7 @@ jobs:
       push: true
       target: sandbox
       context: claude-code/.devcontainer
-      file: Dockerfile
+
       platforms: linux/amd64,linux/arm64
       meta-images: ghcr.io/gatezh/devcontainer-images/claude-code-sandbox
       meta-tags: |

--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -125,7 +125,11 @@ RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --only-shell
 # The installer places the binary in ~/.local/bin/ (previously ~/.claude/bin/).
 # Runtime volume mounts over ~/.claude/ (for config persistence) could shadow it,
 # so copy to a system path to ensure the binary survives volume mounts.
-RUN curl -fsSL https://claude.ai/install.sh | bash
+RUN for i in 1 2 3; do \
+      curl -fsSL https://claude.ai/install.sh | bash && break; \
+      echo "Retry $i/3 in 15s..." && sleep 15; \
+    done \
+  && test -x /home/node/.local/bin/claude
 USER root
 RUN if [ -d /home/node/.local/bin ] && ls /home/node/.local/bin/claude* >/dev/null 2>&1; then \
       cp /home/node/.local/bin/claude* /usr/local/bin/; \


### PR DESCRIPTION
- Add retry with 15s backoff for Claude Code installer (4 parallel builds can trigger rate limiting)
- Remove explicit file: Dockerfile input — github-builder defaults to {context}/Dockerfile which is more reliable with Git URL contexts