### PR TITLE
fix: use npm for Claude Code install in Docker

### DIFF
--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -119,25 +119,16 @@ RUN npx -y playwright@${PLAYWRIGHT_VERSION} install-deps chromium
 USER node
 RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --only-shell
 
-# ── Claude Code CLI (native installer) ───────────────────────────────────────
-# Native installer replaces deprecated npm method (npm install -g @anthropic-ai/claude-code)
-# See: https://code.claude.com/docs/en/getting-started
-# The installer places the binary in ~/.local/bin/ (previously ~/.claude/bin/).
-# Runtime volume mounts over ~/.claude/ (for config persistence) could shadow it,
-# so copy to a system path to ensure the binary survives volume mounts.
-RUN for i in 1 2 3; do \
-      curl -fsSL https://claude.ai/install.sh | bash && break; \
-      echo "Retry $i/3 in 15s..." && sleep 15; \
-    done \
-  && test -x /home/node/.local/bin/claude
+# ── Claude Code CLI ───────────────────────────────────────────────────────────
+# Using npm instead of the native installer (curl claude.ai/install.sh | bash).
+# The native installer is recommended for interactive use, but rate-limits (429)
+# when multiple parallel Docker builds hit it simultaneously.
+# npm is deprecated for interactive users but still supported "for compatibility
+# reasons" — Docker/CI parallel builds are exactly that reason.
+# See: https://code.claude.com/docs/en/getting-started#install-with-npm
+# Auto-updates don't matter here — the image rebuilds daily.
 USER root
-RUN if [ -d /home/node/.local/bin ] && ls /home/node/.local/bin/claude* >/dev/null 2>&1; then \
-      cp /home/node/.local/bin/claude* /usr/local/bin/; \
-    elif [ -d /home/node/.claude/bin ]; then \
-      cp /home/node/.claude/bin/* /usr/local/bin/; \
-    else \
-      echo "ERROR: Claude Code binary not found in ~/.local/bin/ or ~/.claude/bin/" && exit 1; \
-    fi
+RUN npm install -g @anthropic-ai/claude-code
 USER node
 
 # ─── DEFAULT — full dev environment ───────────────────────────────────────────

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -19,7 +19,7 @@ Projects consume these pre-built images and control their own tool versions via 
 | Shell | Fish, Starship, fzf | Built-in syntax highlighting, autosuggestions, completions |
 | Tools | git-delta, gh CLI, jq, nano, vim, wget, unzip, less, man-db, procps | Standard dev utilities |
 | Mise | The tool manager itself (not the tools) | Projects run `mise install` at container creation for their tool versions |
-| Claude Code | Native CLI installer | Binary copied to `/usr/local/bin/` to survive volume mounts |
+| Claude Code | npm global install | npm avoids rate limiting that affects the native installer in parallel CI builds |
 | Playwright | System deps + browser binary at a pinned version | See [Playwright version strategy](#playwright-version-strategy) |
 
 **Default-only:** passwordless sudo, agent-browser + full Chromium


### PR DESCRIPTION
The native installer (curl claude.ai/install.sh) rate-limits (429) when parallel CI builds hit it simultaneously. npm is deprecated for interactive users but explicitly supported "for compatibility reasons" — parallel Docker builds are exactly that.

- Switch to npm install -g @anthropic-ai/claude-code
- Remove retry logic, binary copy hack, and build stagger
- Restore parallel builds (no rate limit risk with npm)