### PR TITLE
docs: update CLAUDE.md and rules for current practices

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,12 +23,14 @@ Dockerfiles for custom devcontainer images on GitHub Container Registry (ghcr.io
 - Always include `latest`
 - Devcontainer: `{tool}{version}-{variant}` (e.g., `bun1.3.5-alpine`)
 - Standalone: `{primary-version}` only (e.g., `0.11.0`)
+- Multi-tool images: `{tool1}{version}-{tool2}{version}` (e.g., `bun1.3.9-hugo0.156.0`)
 
 ## Code Style
 
 - 2-space indentation in JSON/YAML
 - Use comments in devcontainer.json (JSONC format)
 - Dockerfile instruction order: ARG → FROM → packages → user/permissions → tools → LABEL
+- For images with multiple binary downloads, use multi-stage parallel builds (see `ralphex-fe/Dockerfile`)
 
 ## Validation
 

--- a/.claude/rules/dockerfile.md
+++ b/.claude/rules/dockerfile.md
@@ -7,14 +7,14 @@ paths:
 
 ## Required OCI Labels
 
-All Dockerfiles must end with these labels:
+All Dockerfiles must end with a single combined `LABEL` instruction:
 
 ```dockerfile
-LABEL org.opencontainers.image.source="https://github.com/{owner}/devcontainer-images"
-LABEL org.opencontainers.image.description="{Brief description}"
-LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.title="{image-name}"
-LABEL org.opencontainers.image.url="https://github.com/{owner}/devcontainer-images"
+LABEL org.opencontainers.image.source="https://github.com/{owner}/devcontainer-images" \
+      org.opencontainers.image.description="{Brief description}" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="{image-name}" \
+      org.opencontainers.image.url="https://github.com/{owner}/devcontainer-images"
 ```
 
 ## Base Images
@@ -26,7 +26,33 @@ LABEL org.opencontainers.image.url="https://github.com/{owner}/devcontainer-imag
 
 ## Common Packages
 
-Minimal images should include: `ca-certificates`, `git`, `zsh`
+Minimal images should include: `ca-certificates`, `git`
+
+## Docker Best Practices
+
+- **Cache mounts**: Use `--mount=type=cache` for apt and npm to persist download caches between builds:
+  ```dockerfile
+  RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+      --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+      apt-get update && apt-get install -y --no-install-recommends ...
+  ```
+- **Pipefail**: Set `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` before any `curl | bash` pipes, reset with `SHELL ["/bin/sh", "-c"]` after
+- **useradd**: Always use `--no-log-init` to avoid large sparse log files
+- **Downloads**: Use download-then-extract (two commands) instead of `curl | tar` pipes — prevents masked failures under `/bin/sh`
+- **Parallel downloads**: For images with multiple binary tool downloads, use multi-stage builds — BuildKit runs independent stages concurrently. See `ralphex-fe/Dockerfile` for the pattern.
+
+## Playwright on Debian
+
+Use the two-layer strategy (Chromium only for headless testing):
+
+```dockerfile
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    npx -y playwright@${PLAYWRIGHT_VERSION} install-deps chromium
+USER app
+RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --only-shell chromium
+USER root
+```
 
 ## Alpine Playwright Support
 

--- a/.claude/rules/workflows.md
+++ b/.claude/rules/workflows.md
@@ -5,6 +5,23 @@ paths:
 
 # GitHub Actions Workflow Conventions
 
+## Build Approach
+
+Prefer `docker/github-builder` for build workflows — it builds platforms in parallel on native runners (no QEMU). See `build-ralphex-fe.yml` and `build-claude-code.yml` for examples.
+
+The older `reusable-docker-build.yml` uses sequential QEMU-emulated builds and is kept for legacy images.
+
+## Action Versions
+
+Use latest stable major versions. Current:
+- `actions/checkout@v6`
+- `docker/setup-qemu-action@v4`
+- `docker/setup-buildx-action@v4`
+- `docker/login-action@v4`
+- `docker/metadata-action@v6`
+- `docker/build-push-action@v7`
+- `dorny/paths-filter@v4`
+
 ## Triggers
 
 Devcontainer images:
@@ -19,7 +36,7 @@ on:
   workflow_dispatch:
 ```
 
-Standalone images:
+Standalone images (include support files):
 
 ```yaml
 on:
@@ -27,19 +44,13 @@ on:
     branches: [master]
     paths:
       - '{image-name}/Dockerfile'
+      - '{image-name}/files/**'
   workflow_dispatch:
 ```
 
-## Version Extraction
+## CI (Pre-merge)
 
-```yaml
-- name: Extract versions from Dockerfile
-  id: versions
-  run: |
-    DOCKERFILE="{image-name}/.devcontainer/Dockerfile"
-    VERSION=$(grep '^ARG {TOOL}_VERSION=' "$DOCKERFILE" | cut -d'=' -f2)
-    echo "{tool}=$VERSION" >> $GITHUB_OUTPUT
-```
+CI builds amd64 only (native) — no QEMU emulation. arm64 is tested on native runners at merge time.
 
 ## Multi-platform Build
 


### PR DESCRIPTION
## What
Update `.claude/CLAUDE.md` and `.claude/rules/` to reflect conventions established during the ralphex-fe Debian rebuild.

## Why
The ralphex-fe rebuild introduced several new patterns (multi-stage parallel builds, cache mounts, `docker/github-builder`, Chromium-only Playwright) that should be documented for future image work.

## Changes
- **dockerfile.md**: combined LABEL, `--mount=type=cache` for apt/npm, `SHELL` pipefail, `--no-log-init`, download-then-extract, multi-stage parallel downloads pattern, Debian Playwright section
- **workflows.md**: `docker/github-builder` as preferred build approach, current action versions, standalone trigger paths include `files/**`, CI is amd64-only (no QEMU)
- **CLAUDE.md**: multi-stage build reference, multi-tool image tag format (`bun1.3.9-hugo0.156.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)