### PR TITLE
Add CMD sleep infinity to prevent container exit

### DIFF
--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -201,6 +201,8 @@ LABEL org.opencontainers.image.source="https://github.com/gatezh/devcontainer-im
       org.opencontainers.image.title="claude-code" \
       org.opencontainers.image.url="https://github.com/gatezh/devcontainer-images"
 
+CMD ["sleep", "infinity"]
+
 # ─── SANDBOX — network-restricted environment ─────────────────────────────────
 FROM base AS sandbox
 
@@ -229,3 +231,5 @@ LABEL org.opencontainers.image.source="https://github.com/gatezh/devcontainer-im
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.title="claude-code-sandbox" \
       org.opencontainers.image.url="https://github.com/gatezh/devcontainer-images"
+
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary

- Add `CMD ["sleep", "infinity"]` to both `default` and `sandbox` build targets in `claude-code/.devcontainer/Dockerfile`
- Images inherit `CMD ["node"]` from `node:24-trixie-slim`, which exits immediately when used with Docker Compose (where `overrideCommand` defaults to `false`)
- This makes the images work correctly in both `image` mode and Docker Compose mode

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)