### PR TITLE
fix(claude-code): shift scheduled build off the hour to avoid rate limits

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "claude-code/.devcontainer/Dockerfile"
   schedule:
-    - cron: '0 11 * * *'
+    - cron: '13 11 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What
Shift the claude-code scheduled build cron from `0 11 * * *` to `13 11 * * *`.

## Why
The daily build failed with a 429 (Too Many Requests) error when downloading Cosign releases from `raw.githubusercontent.com`. Running exactly on the hour coincides with a GitHub Actions cron stampede — many workflows trigger at `:00`, overwhelming shared CDN endpoints.

## Changes
- Changed cron schedule from `0 11 * * *` to `13 11 * * *` to avoid the top-of-hour spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)