### PR TITLE
feat(ralphex-fe): add RTK for token savings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
             add_image "ralphex-fe" \
               "ralphex-fe" \
               "ralphex-fe/Dockerfile" \
-              "bun --version && hugo version && /srv/ralphex --version"
+              "bun --version && hugo version && /srv/ralphex --version && rtk --version"
           fi
 
           if [ "$INCLUDES" = "[]" ]; then

--- a/ralphex-fe/Dockerfile
+++ b/ralphex-fe/Dockerfile
@@ -43,6 +43,22 @@ RUN set -eux; \
     fi; \
     tar -xzf hugo.tar.gz -C /usr/local/bin/ hugo
 
+# ── RTK (token-optimized CLI proxy for Claude Code) ─────────────────────────
+# Pattern from: .devcontainer/Dockerfile
+FROM alpine:3.21 AS rtk-download
+RUN apk add --no-cache curl jq
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "$ARCH" in \
+      x86_64)  RTK_TARGET="x86_64-unknown-linux-musl" ;; \
+      aarch64) RTK_TARGET="aarch64-unknown-linux-gnu" ;; \
+    esac; \
+    RTK_VERSION=$(curl -fsSL https://api.github.com/repos/rtk-ai/rtk/releases/latest \
+      | jq -r '.tag_name' | sed 's/^v//'); \
+    curl -fsSL -o /tmp/rtk.tar.gz \
+      "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/rtk-${RTK_TARGET}.tar.gz"; \
+    tar -xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk
+
 # ── Ralphex binary (latest from GitHub Releases) ────────────────────────────
 # Pattern from: claude-code/.devcontainer/Dockerfile
 FROM alpine:3.21 AS ralphex-download
@@ -117,6 +133,7 @@ COPY --from=go-download /usr/local/go /usr/local/go
 COPY --from=docker-download /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=hugo-download /usr/local/bin/hugo /usr/local/bin/hugo
 COPY --from=ralphex-download /usr/local/bin/ralphex /srv/ralphex
+COPY --from=rtk-download /usr/local/bin/rtk /usr/local/bin/rtk
 
 ENV GOROOT=/usr/local/go \
     GOPATH=/home/app/go

--- a/ralphex-fe/README.md
+++ b/ralphex-fe/README.md
@@ -17,6 +17,7 @@ This is a standalone image, not a devcontainer.
 | Python 3 | system |
 | Playwright + Chromium | native Debian |
 | Claude Code CLI | latest |
+| RTK | latest (GitHub Releases) |
 | Ralphex | latest (GitHub Releases) |
 | Git, ripgrep, jq, curl, wget | system |
 

--- a/ralphex-fe/init-docker.sh
+++ b/ralphex-fe/init-docker.sh
@@ -27,6 +27,13 @@ if [ -d /mnt/claude ]; then
     fi
 
     chown -R app:app /home/app/.claude
+
+    # ── RTK: ensure rewrite hook is configured ─────────────────────────────
+    # Host mount usually brings the hook, but init idempotently to cover
+    # standalone usage (no host mount). Runs as app user for correct paths.
+    if command -v rtk >/dev/null 2>&1; then
+        gosu app rtk init -g --auto-patch 2>/dev/null || true
+    fi
 fi
 
 # copy credentials extracted from macOS keychain (mounted separately)


### PR DESCRIPTION
Closes #68

## Summary
- Add `rtk-download` parallel build stage to `ralphex-fe/Dockerfile` — same pattern as `.devcontainer/Dockerfile`
- Copy RTK binary to `/usr/local/bin/rtk` in the final image
- Run `rtk init -g --auto-patch` in `init-docker.sh` as idempotent fallback for standalone usage (host mount normally provides the hook)
- Add `rtk --version` to CI verify step
- Add RTK to README tools table

## Test plan
- [ ] CI hadolint passes on `ralphex-fe/Dockerfile`
- [ ] CI build + verify passes (`rtk --version` exits 0)
- [ ] Build locally on ARM64 — RTK binary downloads and runs
- [ ] Run container with host `~/.claude` mount — RTK hook works via copied hooks
- [ ] Run container without mount — `rtk init -g --auto-patch` sets up the hook