### PR TITLE
fix: replace legacy rtk init with hook-first rtk init -g

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "model": "opus",
+  "permissions": {
+    "allow": [
+      "Bash(bun:*)",
+      "Bash(npx:*)",
+      "Bash(git:*)",
+      "Bash(mise:*)",
+      "Bash(curl:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(cat:*)",
+      "Bash(find:*)"
+    ]
+  },
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.devcontainer/init-plugins.sh
+++ b/.devcontainer/init-plugins.sh
@@ -44,9 +44,10 @@ for plugin in "${PLUGINS[@]}"; do
     }
 done
 
-# Initialize rtk global hook for Claude Code (auto-rewrite mode)
+# Initialize rtk global hook for Claude Code (auto-rewrite mode).
+# --hook-only: installs only the PreToolUse rewrite hook, no workspace artifacts.
 echo "Initializing rtk (token optimizer)..."
-rtk init -g --auto-patch || {
+rtk init -g --hook-only --auto-patch || {
     echo "Note: rtk init may have already been configured or rtk not available"
 }
 

--- a/claude-code/.devcontainer/init-plugins.sh
+++ b/claude-code/.devcontainer/init-plugins.sh
@@ -47,10 +47,10 @@ if [ "$(uname -m)" = "aarch64" ] && [ -f "$PLAYWRIGHT_MCP_CONFIG" ]; then
 fi
 
 # ── rtk init (token-optimized CLI proxy) ────────────────────────────────────
-# Configures rtk for the current workspace. Safe to run multiple times.
-# rtk is pre-installed in the devcontainer image.
+# Global hook-first mode: installs only the PreToolUse rewrite hook to ~/.claude/,
+# no workspace artifacts (CLAUDE.md, .rtk/). Safe to run multiple times.
 if command -v rtk &>/dev/null; then
-    rtk init 2>/dev/null || true
+    rtk init -g --hook-only --auto-patch 2>/dev/null || true
 fi
 
 # ── agent-browser skill ─────────────────────────────────────────────────────

--- a/ralphex-fe/init-docker.sh
+++ b/ralphex-fe/init-docker.sh
@@ -30,9 +30,9 @@ if [ -d /mnt/claude ]; then
 
     # ── RTK: ensure rewrite hook is configured ─────────────────────────────
     # Host mount usually brings the hook, but init idempotently to cover
-    # standalone usage (no host mount). Runs as app user for correct paths.
+    # standalone usage (no host mount). --hook-only avoids workspace artifacts.
     if command -v rtk >/dev/null 2>&1; then
-        gosu app rtk init -g --auto-patch 2>/dev/null || true
+        gosu app rtk init -g --hook-only --auto-patch 2>/dev/null || true
     fi
 fi
 


### PR DESCRIPTION
## What
Replace `rtk init` (legacy local mode) with `rtk init -g --hook-only --auto-patch` across all init scripts. Also track `.claude/settings.json` project config.

## Why
The legacy `rtk init` creates workspace artifacts (`CLAUDE.md`, `.rtk/filters.toml`) that pollute `git status`, shadow project CLAUDE.md files, and waste ~3K context tokens per conversation. Since RTK v0.10+, the hook-first `-g` mode installs only a `PreToolUse` rewrite hook to `~/.claude/` — zero workspace files, zero context overhead.

## Changes
- **`claude-code/.devcontainer/init-plugins.sh`**: `rtk init` → `rtk init -g --hook-only --auto-patch` (the main fix)
- **`.devcontainer/init-plugins.sh`**: add `--hook-only` flag (already had `-g --auto-patch`)
- **`ralphex-fe/init-docker.sh`**: add `--hook-only` flag (already had `-g --auto-patch`)
- **`.claude/settings.json`**: track project-level Claude Code config (model, permissions, attribution)

Closes #71