### PR TITLE
fix(claude-code): limit Playwright browser download to Chromium only

### DIFF
--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -142,7 +142,7 @@ COPY --from=ralphex-download /usr/local/bin/ralphex /usr/local/bin/ralphex
 #   1. System deps (install-deps) — heavy, needs root, version-stable across
 #      nearby releases. Baked into the image so projects don't need sudo.
 #   2. Browser binary (install --only-shell) — light, version-specific.
-#      Baked as a cache; projects MUST run `npx playwright install --only-shell`
+#      Baked as a cache; projects MUST run `npx playwright install --only-shell chromium`
 #      at container creation to ensure the binary matches their @playwright/test.
 #      That command is idempotent: no-op when versions match, ~10s download if not.
 USER root

--- a/claude-code/.devcontainer/claude-sandbox/devcontainer.json
+++ b/claude-code/.devcontainer/claude-sandbox/devcontainer.json
@@ -122,7 +122,7 @@
   },
   // Runs before postStartCommand (firewall), so network is still available for browser downloads.
   // The find command chowns all node_modules volume mount points in one pass.
-  "postCreateCommand": "sudo find /workspace -maxdepth 4 -name node_modules -type d -exec chown node {} + && sudo chown -R node /home/node/.claude && mise install && bun install && npx playwright install --only-shell",
+  "postCreateCommand": "sudo find /workspace -maxdepth 4 -name node_modules -type d -exec chown node {} + && sudo chown -R node /home/node/.claude && mise install && bun install && npx playwright install --only-shell chromium",
   // Firewall init — script is bind-mounted from the project
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"

--- a/claude-code/.devcontainer/devcontainer.json
+++ b/claude-code/.devcontainer/devcontainer.json
@@ -110,6 +110,6 @@
   // mise install reads .mise.toml and installs project-specific tool versions.
   // playwright install ensures the correct browser binary for the project's @playwright/test version
   // (idempotent — skips download if the image's cached binary already matches).
-  "updateContentCommand": "sudo find /workspace -maxdepth 4 -name node_modules -type d -exec chown node {} + && sudo chown -R node /home/node/.claude && mise install && bun install && npx playwright install --only-shell",
+  "updateContentCommand": "sudo find /workspace -maxdepth 4 -name node_modules -type d -exec chown node {} + && sudo chown -R node /home/node/.claude && mise install && bun install && npx playwright install --only-shell chromium",
   "waitFor": "postCreateCommand"
 }

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -230,7 +230,7 @@ bun add -d @playwright/test    # or: npm install -D @playwright/test
 **One-time project setup** — add this to your container creation command (`updateContentCommand` or `postCreateCommand`, as shown in [Quick Start](#quick-start)):
 
 ```bash
-npx playwright install --only-shell
+npx playwright install --only-shell chromium
 ```
 
 This is **idempotent** — if the cached binary already matches, it's a no-op (~0s). If the project's `@playwright/test` version differs from the image, it downloads the correct binary (~10s, once at container creation).
@@ -316,7 +316,7 @@ docker buildx build \
 Pull image ──────────────────────── (cached)
 mise install (bun, hugo, etc.) ──── (~15s, downloads pre-built binaries)
 bun install ─────────────────────── (~15s, cached in named volume)
-playwright install --only-shell ─── (~0s, binary already cached — no-op)
+playwright install --only-shell chromium  (~0s, binary already cached — no-op)
 project setup ───────────────────── (db:migrate, init-plugins, etc.)
                                      Total: ~45s warm
 ```
@@ -326,7 +326,7 @@ project setup ───────────────────── (d
 Pull image ──────────────────────── (cached)
 mise install (bun, hugo, etc.) ──── (~15s)
 bun install ─────────────────────── (~15s)
-playwright install --only-shell ─── (~10s, downloads correct browser binary)
+playwright install --only-shell chromium  (~10s, downloads correct browser binary)
 project setup ───────────────────── (db:migrate, init-plugins, etc.)
                                      Total: ~55s warm
 ```


### PR DESCRIPTION
## What
Append `chromium` to all `npx playwright install --only-shell` commands so only the Chromium headless shell is downloaded.

## Why
`--only-shell` controls the browser **variant** (headless shell vs full), not **which** browsers are installed. Without a browser argument, Playwright downloads all three (Chromium, Firefox, WebKit — ~290 MiB on ARM64), wasting ~184 MiB on browsers that are never used.

## Changes
- `devcontainer.json` — add `chromium` arg to `updateContentCommand`
- `claude-sandbox/devcontainer.json` — add `chromium` arg to `postCreateCommand`
- `Dockerfile` — update the comment documenting the expected install command
- `README.md` — update all three code/diagram references

Closes #78