### PR TITLE
fix: work around RTK v0.36.0 GDPR consent hang in non-interactive builds

### DIFF
--- a/.devcontainer/init-plugins.sh
+++ b/.devcontainer/init-plugins.sh
@@ -46,8 +46,11 @@ done
 
 # Initialize rtk global hook for Claude Code (auto-rewrite mode).
 # --hook-only: installs only the PreToolUse rewrite hook, no workspace artifacts.
+# WORKAROUND: RTK ≥0.36.0 added a GDPR telemetry consent prompt that hangs in
+# non-interactive environments. timeout + RTK_TELEMETRY_DISABLED work around it.
+# Remove when upstream fixes it: https://github.com/rtk-ai/rtk/issues/1307
 echo "Initializing rtk (token optimizer)..."
-rtk init -g --hook-only --auto-patch || {
+RTK_TELEMETRY_DISABLED=1 timeout 10 rtk init -g --hook-only --auto-patch || {
     echo "Note: rtk init may have already been configured or rtk not available"
 }
 

--- a/claude-code/.devcontainer/init-plugins.sh
+++ b/claude-code/.devcontainer/init-plugins.sh
@@ -75,8 +75,11 @@ fi
 # ── rtk init (token-optimized CLI proxy) ────────────────────────────────────
 # Global hook-first mode: installs only the PreToolUse rewrite hook to ~/.claude/,
 # no workspace artifacts (CLAUDE.md, .rtk/). Safe to run multiple times.
+# WORKAROUND: RTK ≥0.36.0 added a GDPR telemetry consent prompt that hangs in
+# non-interactive environments. timeout + RTK_TELEMETRY_DISABLED work around it.
+# Remove when upstream fixes it: https://github.com/rtk-ai/rtk/issues/1307
 if command -v rtk &>/dev/null; then
-    rtk init -g --hook-only --auto-patch 2>/dev/null || true
+    RTK_TELEMETRY_DISABLED=1 timeout 10 rtk init -g --hook-only --auto-patch 2>/dev/null || true
 fi
 
 # ── agent-browser skill ─────────────────────────────────────────────────────

--- a/ralphex-fe/init-docker.sh
+++ b/ralphex-fe/init-docker.sh
@@ -31,8 +31,11 @@ if [ -d /mnt/claude ]; then
     # ── RTK: ensure rewrite hook is configured ─────────────────────────────
     # Host mount usually brings the hook, but init idempotently to cover
     # standalone usage (no host mount). --hook-only avoids workspace artifacts.
+    # WORKAROUND: RTK ≥0.36.0 added a GDPR telemetry consent prompt that hangs
+    # in non-interactive environments. Remove when upstream fixes it:
+    # https://github.com/rtk-ai/rtk/issues/1307
     if command -v rtk >/dev/null 2>&1; then
-        gosu app rtk init -g --hook-only --auto-patch 2>/dev/null || true
+        RTK_TELEMETRY_DISABLED=1 gosu app timeout 10 rtk init -g --hook-only --auto-patch 2>/dev/null || true
     fi
 fi
 


### PR DESCRIPTION
## What
Prevents `rtk init` from hanging indefinitely during devcontainer/Docker builds due to the GDPR telemetry consent prompt introduced in RTK v0.36.0.

## Why
RTK v0.36.0 added an interactive telemetry consent gate that blocks on stdin. In non-interactive environments (devcontainer `postCreateCommand`, Docker entrypoints), there's no stdin — so the process hangs forever, preventing containers from starting.

## Changes
- Add `timeout 10` to all `rtk init` invocations so the process is killed after hook setup completes (the consent prompt is the only thing that blocks past that point)
- Set `RTK_TELEMETRY_DISABLED=1` as defense-in-depth to disable data collection
- Affected files: `.devcontainer/init-plugins.sh`, `claude-code/.devcontainer/init-plugins.sh`, `ralphex-fe/init-docker.sh`

## Notes
This is a **temporary workaround** until the upstream fix lands: https://github.com/rtk-ai/rtk/issues/1307. All three patched files have a `WORKAROUND` comment with the upstream link so it can be cleaned up later.

Closes #77