### PR TITLE
ci: manual cleanup workflow for claude-code GHCR images

### DIFF
--- a/.github/workflows/cleanup-claude-code-ghcr.yml
+++ b/.github/workflows/cleanup-claude-code-ghcr.yml
@@ -1,0 +1,51 @@
+# Manually-triggered cleanup of old GHCR versions for the claude-code images.
+#
+# Scope: ghcr.io/gatezh/devcontainers/claude-code and
+#        ghcr.io/gatezh/devcontainers/claude-code-sandbox only.
+# Other packages in this repo (bun, hugo-bun, hugo-bun-node, ralphex-fe,
+# claude-bun) are unreachable from this workflow.
+#
+# Inputs are typed (number, boolean) workflow_dispatch values consumed only
+# as action `with:` parameters, never interpolated into shell commands, so
+# command-injection from event payloads does not apply here.
+#
+# One-time setup: each target package must grant this repository the "Admin"
+# role under Package Settings -> Manage Actions access (GHCR UI). Without
+# this, deletions return 403.
+name: Cleanup claude-code GHCR versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      retention-days:
+        description: "Delete versions older than this many days"
+        type: number
+        default: 90
+      dry-run:
+        description: "Preview deletions without actually deleting"
+        type: boolean
+        default: true
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Cleanup ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [claude-code, claude-code-sandbox]
+    steps:
+      - name: Delete old container versions
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: gatezh
+          package: devcontainers/${{ matrix.package }}
+          older-than: ${{ inputs.retention-days }} days
+          delete-tags: '*'
+          delete-untagged: true
+          exclude-tags: latest
+          dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
## What
Adds a manually-triggered GitHub Actions workflow that prunes old container versions of the `claude-code` and `claude-code-sandbox` packages on GHCR.

## Why
`build-claude-code.yml` runs daily and pushes three new tags per image (`latest`, `<sha>`, `<YYYYMMDD>`) for two architectures. Each time `latest` moves, the previous manifest becomes untagged but stays forever — GHCR never auto-prunes. Over months this clutters the package version list and slows API paging. Public packages have free unlimited storage on GHCR, so this is a hygiene improvement, not a cost fix.

Other images in this repo (`bun`, `hugo-bun`, `hugo-bun-node`, `ralphex-fe`, `claude-bun`) only rebuild on Dockerfile changes and don't have the same accumulation problem, so they're explicitly out of scope.

## Changes
- New file: `.github/workflows/cleanup-claude-code-ghcr.yml`
  - Trigger: `workflow_dispatch` only — no cron, no automatic execution
  - Inputs: `retention-days` (default `90`), `dry-run` (default `true`)
  - Matrix over `[claude-code, claude-code-sandbox]` so each package is processed independently
  - Uses `dataaxiom/ghcr-cleanup-action@v1`, which is multi-arch-safe (it skips child manifests still referenced by tagged manifest lists)
  - `exclude-tags: latest` unconditionally preserves the moving `latest` pointer

## Notes
**One-time setup required before the first real run:** for each of the two packages, open *Package settings → Manage Actions access* in the GHCR UI, add this repository, and grant **Admin**. Without that, the action returns 403.

**Verification (post-merge, since `workflow_dispatch` only resolves once on `master`):**
1. From the Actions tab → *Cleanup claude-code GHCR versions* → **Run workflow** with defaults (dry-run on). Read both matrix job logs to confirm `latest` is preserved and only versions older than 90 days are listed.
2. Re-run with the dry-run checkbox unchecked for the real prune.
3. Sanity-check `docker manifest inspect ghcr.io/gatezh/devcontainers/claude-code:latest` still returns both `linux/amd64` and `linux/arm64` entries.

CI will only run `actionlint` on this PR (no Dockerfile changes); `actionlint` was also run locally and passes.