### PR TITLE
fix(ci): verify AGENT_BROWSER_EXECUTABLE_PATH without runner-shell expansion

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -76,11 +76,11 @@ jobs:
       matrix:
         include:
           - image-suffix: claude-code
-            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && test \"$AGENT_BROWSER_EXECUTABLE_PATH\" = /usr/bin/chromium"
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
             runner: ubuntu-24.04
             arch: amd64
           - image-suffix: claude-code
-            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && test \"$AGENT_BROWSER_EXECUTABLE_PATH\" = /usr/bin/chromium"
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
             runner: ubuntu-24.04-arm
             arch: arm64
           - image-suffix: claude-code-sandbox


### PR DESCRIPTION
## What
Hotfix the failing `Verify claude-code (amd64)` and `Verify claude-code (arm64)` stages introduced in #92. Image is fine — only the verify step was broken.

## Why
#92 added this to the default-target verify command:

```
test "$AGENT_BROWSER_EXECUTABLE_PATH" = /usr/bin/chromium
```

When GitHub Actions interpolates `\${{ matrix.verify-command }}` into the workflow's `bash -c "..."` invocation, the runner's bash sees `$AGENT_BROWSER_EXECUTABLE_PATH` and expands it **before** docker runs — but the env var is set in the **container**, not the runner. So the runner expands it to empty string, and the container's bash receives `test  = /usr/bin/chromium` (with an empty argument), which fails with `bash: line 1: test: =: unary operator expected`.

Reproduced from the failure log:
```
bash: line 1: test: =: unary operator expected
##[error]Process completed with exit code 2.
```

## Fix
Replace `test "$VAR" = /value` with `printenv VAR | grep -qx /value`. The `printenv`-pipe form has zero shell metacharacters in the substituted string — the runner's shell has nothing to expand, so the entire command reaches the container's bash intact, and `printenv` reads the env var from inside the container.

## Verification
The image itself is correct — the `ENV` instruction took effect:

```sh
$ docker inspect ghcr.io/gatezh/devcontainers/claude-code:latest --format '{{range .Config.Env}}{{println .}}{{end}}' | grep AGENT_BROWSER
AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
```

End-to-end test of the new verify command against the live image:

```sh
$ docker run --rm ghcr.io/gatezh/devcontainers/claude-code:latest bash -c "... && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium" && echo "EXIT=\$?"
2.1.123 (Claude Code)
2026.4.28 linux-arm64 (2026-04-30)
fish, version 4.0.2
rtk 0.38.0
ralphex v1.0.1-0a54e09-20260421T215012
EXIT=0
```

Exit 0 with the env var set; exit 1 if it were unset (`printenv` exits non-zero on missing var, breaking the pipeline).

## Notes
Sandbox-target verify lines unchanged — they don't reference `\$AGENT_BROWSER_EXECUTABLE_PATH` (agent-browser isn't installed there).

This is the kind of bug that's invisible in static YAML parsing — the rendered `bash -c` string parses fine; the issue is only in **which shell** processes the `$VAR` reference. Lesson noted for future env-var verifies: prefer `printenv` over `test "\$VAR"` to keep the boundary clean.