### PR TITLE
fix(init-firewall): unblock startup on dead allowlist host (#94)

### DIFF
--- a/.devcontainer/claude-sandbox/init-firewall.sh
+++ b/.devcontainer/claude-sandbox/init-firewall.sh
@@ -63,7 +63,6 @@ for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
     "sentry.io" \
-    "statsig.anthropic.com" \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \
@@ -74,8 +73,8 @@ for domain in \
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
-        echo "ERROR: Failed to resolve $domain"
-        exit 1
+        echo "WARN: Failed to resolve $domain — skipping"
+        continue
     fi
 
     while read -r ip; do

--- a/claude-bun/.devcontainer/init-firewall.sh
+++ b/claude-bun/.devcontainer/init-firewall.sh
@@ -60,7 +60,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # Resolve and add other allowed domains
@@ -68,7 +68,6 @@ for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
     "sentry.io" \
-    "statsig.anthropic.com" \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \
@@ -76,8 +75,8 @@ for domain in \
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
-        echo "ERROR: Failed to resolve $domain"
-        exit 1
+        echo "WARN: Failed to resolve $domain — skipping"
+        continue
     fi
 
     while read -r ip; do
@@ -86,7 +85,7 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
## What
Fixes #94. `init-firewall.sh` no longer aborts container startup when an allowlist host stops resolving in DNS, and removes the now-dead `statsig.anthropic.com` entry that triggered the regression.

## Why
`statsig.anthropic.com` has been retired as part of Anthropic's ongoing migration off Statsig (anthropics/claude-code#7151). The resolver loop in both copies of `init-firewall.sh` treated any unresolvable host as fatal (`exit 1`), so VS Code's `postStartCommand` failed and the devcontainer was unusable for any consumer that bind-mounts these scripts unmodified — including the `claude-code` template, `claude-bun`, and this repo's own sandbox. Same upstream bug is open as anthropics/claude-code#55623.

## Changes
- **Drop `statsig.anthropic.com`** from the allowlist loop in `.devcontainer/claude-sandbox/init-firewall.sh` and `claude-bun/.devcontainer/init-firewall.sh`. `statsig.com` stays.
- **Make the resolver tolerant**: log `WARN: Failed to resolve <host> — skipping` and `continue` instead of `exit 1`. The default-DROP `OUTPUT` policy plus the explicit REJECT keep the perimeter fail-closed — a skipped host simply gets no allow rule, which is the right posture.
- **Adjacent consistency fix in `claude-bun`**: add `-exist` to both `ipset add` calls so duplicate IPs from DNS no longer abort the script. `claude-sandbox` already used `-exist`; this brings `claude-bun` into line and avoids the latent failure mode reported in anthropics/claude-code#35197.

## Notes
- The fail-closed contract is unchanged: any host that fails resolution is silently denied, not allowed.
- No `devcontainer.json`, README, or CI workflow changes — same script contract, same invocation path.
- The `claude-code` plugin variant doesn't ship its own copy of the script (bind-mount), so its consumers inherit the fix automatically.

## Test plan
- [ ] Rebuild `claude-sandbox` devcontainer: `postStartCommand` finishes without `Failed to resolve` aborting the run.
- [ ] Rebuild `claude-bun` devcontainer: same.
- [ ] In each container, the script's own self-tests pass — `https://example.com` is blocked, `https://api.github.com/zen` is reachable.
- [ ] `bash -n` syntax check on both scripts (already run locally — passes).