### PR TITLE
fix(claude-code): patch playwright MCP on every session start (#98)

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "claude-code/.devcontainer/Dockerfile"
       - "claude-code/.devcontainer/*.sh"
+      - "claude-code/.devcontainer/managed-settings.json"
   schedule:
     - cron: '13 11 * * *'
   workflow_dispatch:
@@ -76,19 +77,19 @@ jobs:
       matrix:
         include:
           - image-suffix: claude-code
-            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -e '.hooks.SessionStart[0].hooks[0].command == \"/usr/local/bin/patch-playwright-mcp\"' /etc/claude-code/managed-settings.json >/dev/null && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
             runner: ubuntu-24.04
             arch: amd64
           - image-suffix: claude-code
-            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -e '.hooks.SessionStart[0].hooks[0].command == \"/usr/local/bin/patch-playwright-mcp\"' /etc/claude-code/managed-settings.json >/dev/null && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
             runner: ubuntu-24.04-arm
             arch: arm64
           - image-suffix: claude-code-sandbox
-            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp"
+            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -e '.hooks.SessionStart[0].hooks[0].command == \"/usr/local/bin/patch-playwright-mcp\"' /etc/claude-code/managed-settings.json >/dev/null"
             runner: ubuntu-24.04
             arch: amd64
           - image-suffix: claude-code-sandbox
-            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp"
+            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -e '.hooks.SessionStart[0].hooks[0].command == \"/usr/local/bin/patch-playwright-mcp\"' /etc/claude-code/managed-settings.json >/dev/null"
             runner: ubuntu-24.04-arm
             arch: arm64
     runs-on: ${{ matrix.runner }}

--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -140,9 +140,17 @@ COPY --from=ralphex-download /usr/local/bin/ralphex /usr/local/bin/ralphex
 # ── Playwright MCP patch script ──────────────────────────────────────────────
 # Universal logic with no project-specific config — bake into the image so
 # consumer projects don't carry a copy. Invoked from postCreateCommand
-# (init-plugins.sh) and postStartCommand (devcontainer.json) to re-patch
-# plugin auto-updates between sessions. See issue #87.
+# (init-plugins.sh), postStartCommand (devcontainer.json), and the Claude Code
+# SessionStart hook (managed-settings.json below) — the hook closes the gap
+# where the plugin auto-updates mid-container-run. See issues #87, #98.
 COPY --chmod=0755 patch-playwright-mcp.sh /usr/local/bin/patch-playwright-mcp
+
+# ── Claude Code managed settings ─────────────────────────────────────────────
+# Image-policy settings at the Linux managed location (highest precedence,
+# outside any volume mount). Wires patch-playwright-mcp as a SessionStart hook
+# so cache dirs created by mid-session plugin auto-updates get patched before
+# the next session reads them. See issue #98.
+COPY --chmod=0644 managed-settings.json /etc/claude-code/managed-settings.json
 
 # ── Claude Code CLI ───────────────────────────────────────────────────────────
 # Using npm instead of the native installer (curl claude.ai/install.sh | bash).

--- a/claude-code/.devcontainer/claude-sandbox/devcontainer.json
+++ b/claude-code/.devcontainer/claude-sandbox/devcontainer.json
@@ -124,9 +124,9 @@
   // Chromium is baked into the sandbox image (firewall blocks runtime install).
   "postCreateCommand": "sudo find /workspace -maxdepth 4 -name node_modules -type d -exec chown node {} + && sudo chown -R node /home/node/.claude && mise install && bun install",
   // Firewall init (bind-mounted from project) + re-patch the Playwright MCP
-  // plugin's .mcp.json. The patch runs on every start so plugin auto-updates
-  // between sessions don't leave MCP pointing at the missing chrome channel.
-  // See issues #85, #87.
+  // plugin's .mcp.json. The patch is defense in depth alongside the SessionStart
+  // hook in /etc/claude-code/managed-settings.json, which handles the case where
+  // the plugin auto-updates mid-container-run. See issues #85, #87, #98.
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh && /usr/local/bin/patch-playwright-mcp",
   "waitFor": "postStartCommand"
 }

--- a/claude-code/.devcontainer/devcontainer.json
+++ b/claude-code/.devcontainer/devcontainer.json
@@ -111,10 +111,10 @@
   // Chromium is baked into the image via apt — no playwright install step needed.
   // Projects' playwright.config.ts should use process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH.
   "updateContentCommand": "sudo find /workspace -maxdepth 4 -name node_modules -type d -exec chown node {} + && sudo chown -R node /home/node/.claude && mise install && bun install",
-  // Re-patch the Playwright MCP plugin's .mcp.json on every start.
-  // Plugin auto-updates between sessions create new cache dirs whose .mcp.json
-  // points at /opt/google/chrome/chrome (which we don't ship). Without this,
-  // MCP silently breaks until the next image rebuild. See issues #85, #87.
+  // Re-patch the Playwright MCP plugin's .mcp.json on every start. Defense in
+  // depth alongside the SessionStart hook in /etc/claude-code/managed-settings.json,
+  // which handles the case where the plugin auto-updates mid-container-run.
+  // See issues #85, #87, #98.
   "postStartCommand": "/usr/local/bin/patch-playwright-mcp",
   "waitFor": "postCreateCommand"
 }

--- a/claude-code/.devcontainer/init-plugins.sh
+++ b/claude-code/.devcontainer/init-plugins.sh
@@ -59,7 +59,8 @@ done
 # ── Playwright MCP: route every cached .mcp.json to system chromium ─────────
 # Universal across arches (no Chrome stable binary in either default or sandbox).
 # The patch binary is baked into the image (see Dockerfile #87) and also runs
-# from postStartCommand to catch plugin auto-updates between sessions (#85).
+# from postStartCommand (#85) and a Claude Code SessionStart hook (#98) — the
+# hook is what closes the gap when the plugin auto-updates mid-container-run.
 /usr/local/bin/patch-playwright-mcp
 
 # ── rtk init (token-optimized CLI proxy) ────────────────────────────────────

--- a/claude-code/.devcontainer/managed-settings.json
+++ b/claude-code/.devcontainer/managed-settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/patch-playwright-mcp"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What
Wires `patch-playwright-mcp` as a Claude Code `SessionStart` hook via an image-baked `/etc/claude-code/managed-settings.json`, so the patch runs before any MCP launches in every new or resumed session — not just at container start.

## Why
Closes #98. The playwright plugin can auto-update **mid-container-run**, extracting a fresh cache dir whose `.mcp.json` defaults to `--browser chrome` and points at `/opt/google/chrome/chrome` (not shipped in this image). Existing `postCreateCommand`/`postStartCommand` wiring only patches cache dirs that exist *at the moment they run* — anything created later stays broken until the next container restart, producing:

```
Error: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
```

`SessionStart` is the canonical Claude Code hook for "run before the first prompt of every session" and is documented to run synchronously before the model receives input, so by the time MCP launches the patched `.mcp.json` is already on disk.

The settings file lives at the Linux managed-settings path (`/etc/claude-code/managed-settings.json`) so it has highest precedence, sits outside the `/home/node/.claude` named volume, and survives volume re-creation across container rebuilds.

## Changes
- **Add `claude-code/.devcontainer/managed-settings.json`** — `SessionStart` hook entry invoking `/usr/local/bin/patch-playwright-mcp` on all session sources (startup, resume, clear, compact). Matcher omitted; the patch is idempotent and ~20 ms.
- **`claude-code/.devcontainer/Dockerfile`** — `COPY` the new file to `/etc/claude-code/managed-settings.json` for both default and sandbox targets (shared `base` stage).
- **`.github/workflows/build-claude-code.yml`** — extend the build trigger `paths:` filter to pick up `managed-settings.json`; add a `jq -e` assertion to the verify matrix on all four target × arch combinations confirming the hook is actually present in the published image.
- **`claude-code/.devcontainer/devcontainer.json` + `claude-sandbox/devcontainer.json` + `init-plugins.sh`** — update comments to describe `postCreateCommand`/`postStartCommand` as defense in depth alongside the new hook, and add issue #98 cross-references.

## Notes
- **No script changes.** `patch-playwright-mcp` was already idempotent and looped over every cache dir; this PR only adds a third invocation cadence.
- **Existing devcontainers won't get the hook until they rebuild from a refreshed image.** The Dockerfile change forces a `latest` rebuild; downstream projects pick it up on next image pull.
- **Verified canonical against upstream docs (2026-05-12):**
  - `SessionStart` hook schema and stdin payload per `code.claude.com/docs/en/hooks`.
  - Linux managed-settings path per `code.claude.com/docs/en/settings`.
  - `--browser chromium`, `--executable-path`, `--no-sandbox`, `--headless` flags valid in `@playwright/mcp` v0.0.75 (README + upstream Dockerfile `ENTRYPOINT`).

## Test plan
- [x] `jq` parse of `managed-settings.json` succeeds and verify-command predicate evaluates `true` locally.
- [x] `hadolint` clean on modified Dockerfile (against `.hadolint.yaml`).
- [x] `actionlint` clean on modified workflow.
- [ ] CI build succeeds and the new `jq -e` verify assertion passes on all four target × arch combinations.
- [ ] In a refreshed devcontainer, observe `.mcp.json` mtimes update at every session start (not just container start), and confirm `mcp__plugin_playwright_playwright__*` tools work after a mid-session plugin auto-update.

Closes #98.