### PR TITLE
fix(claude-code): create /etc/claude-code as root so managed-settings is readable

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -77,19 +77,19 @@ jobs:
       matrix:
         include:
           - image-suffix: claude-code
-            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && test -r /etc/claude-code/managed-settings.json && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
             runner: ubuntu-24.04
             arch: amd64
           - image-suffix: claude-code
-            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
+            verify-command: "bun --version || true && claude --version && mise --version && fish --version && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && test -r /etc/claude-code/managed-settings.json && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp && printenv AGENT_BROWSER_EXECUTABLE_PATH | grep -qx /usr/bin/chromium"
             runner: ubuntu-24.04-arm
             arch: arm64
           - image-suffix: claude-code-sandbox
-            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp"
+            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && test -r /etc/claude-code/managed-settings.json && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp"
             runner: ubuntu-24.04
             arch: amd64
           - image-suffix: claude-code-sandbox
-            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp"
+            verify-command: "claude --version && mise --version && fish --version && which iptables && rtk --version && ralphex --version && test -x /usr/local/bin/patch-playwright-mcp && test -r /etc/claude-code/managed-settings.json && jq -r '.hooks.SessionStart[0].hooks[0].command' /etc/claude-code/managed-settings.json | grep -qx /usr/local/bin/patch-playwright-mcp"
             runner: ubuntu-24.04-arm
             arch: arm64
     runs-on: ${{ matrix.runner }}

--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -149,8 +149,16 @@ COPY --chmod=0755 patch-playwright-mcp.sh /usr/local/bin/patch-playwright-mcp
 # Image-policy settings at the Linux managed location (highest precedence,
 # outside any volume mount). Wires patch-playwright-mcp as a SessionStart hook
 # so cache dirs created by mid-session plugin auto-updates get patched before
-# the next session reads them. See issue #98.
-COPY --chmod=0644 managed-settings.json /etc/claude-code/managed-settings.json
+# the next session reads them. See issues #98, #101.
+#
+# Pre-create /etc/claude-code as root: BuildKit applies COPY --chmod to any
+# parent directories it auto-creates, which would leave the dir at mode 0644
+# (no execute bit, not traversable). Creating it explicitly avoids that and
+# makes the file readable for the node user at runtime.
+USER root
+RUN mkdir -p /etc/claude-code
+COPY --chown=root:root --chmod=0644 managed-settings.json /etc/claude-code/managed-settings.json
+USER node
 
 # ── Claude Code CLI ───────────────────────────────────────────────────────────
 # Using npm instead of the native installer (curl claude.ai/install.sh | bash).


### PR DESCRIPTION
## What
Pre-creates `/etc/claude-code` as root before `COPY`-ing `managed-settings.json` into it, and adds a `test -r` precondition to the CI verify-command.

## Why
PR #100's image-rebuild run ([25776401543](https://github.com/gatezh/devcontainers/actions/runs/25776401543)) failed all four verify legs with:

```
jq: error: Could not open file /etc/claude-code/managed-settings.json: Permission denied
```

Reproduced locally against the published image at digest `sha256:2b31ced4…`:

```
$ docker run --rm ghcr.io/gatezh/devcontainers/claude-code:latest \
    ls -ld /etc/claude-code
drw-r--r-- 2 root root 4096 May 13 03:28 /etc/claude-code
```

Mode `0644` on a directory means readable but **not** traversable — the file inside is unreachable by any user, including root inside this container.

Root cause: BuildKit applies `COPY --chmod=N` not only to the file but to **any parent directories it auto-creates**. The previous `COPY --chmod=0644 managed-settings.json /etc/claude-code/managed-settings.json` created `/etc/claude-code` with mode `0644` (no `x` bit) as a side effect.

The file mode itself was correct; the bug was relying on BuildKit to materialize the parent dir with a sane default.

## Changes
- **`claude-code/.devcontainer/Dockerfile`** — switch to `USER root`, `mkdir -p /etc/claude-code` (inherits root's umask → `0755`), `COPY --chown=root:root --chmod=0644 managed-settings.json …`, then drop back to `USER node`. Adds the file under standard `/etc/` ownership conventions.
- **`.github/workflows/build-claude-code.yml`** — prefix the four verify-command rows with `test -r /etc/claude-code/managed-settings.json` so the next time this directory perm class of bug appears, CI fails with an explicit "file not readable" before jq is invoked. Same `printenv | grep -qx` quote-free shape as the surrounding checks.

## Notes
- **Verified locally — for real this time.** Built `--target base` from the modified Dockerfile, confirmed `/etc/claude-code` is now `drwxr-xr-x` and `managed-settings.json` is `-rw-r--r--`, ran the exact verify-command under `bash -c "<value>"` (matching the GHA matrix expansion) inside the container — exit 0.
- **Lesson logged**: my "local verification" on PRs #99 and #100 was insufficient because I only validated the *predicate* against a *copy* of the JSON file at a path I controlled. The published image's actual perms were never checked. From now on, image-changing PRs need a `docker build --target <stage>` + in-container repro before push, not just a syntactic check of the diff.

## Test plan
- [x] `hadolint` clean on modified Dockerfile.
- [x] `actionlint` clean on modified workflow.
- [x] Locally built image: `/etc/claude-code` mode `0755`, file mode `0644`, readable as `node`.
- [x] Exact verify-command under `bash -c "<value>"` exits 0 in the locally built image.
- [ ] CI `Build claude-code` post-merge run on master — all four verify legs (default/sandbox × amd64/arm64) should pass.

Recovers from #99 / #100. Closes the loop on #98.