### PR TITLE
feat(claude-code): add modern-web-guidance plugin and document bundled plugins

### DIFF
--- a/claude-code/.devcontainer/init-plugins.sh
+++ b/claude-code/.devcontainer/init-plugins.sh
@@ -22,6 +22,7 @@ fi
 MARKETPLACES=(
     "anthropics/claude-plugins-official"
     "umputun/ralphex"
+    "GoogleChrome/modern-web-guidance"
 )
 
 for marketplace in "${MARKETPLACES[@]}"; do
@@ -46,6 +47,7 @@ PLUGINS=(
     "claude-code-setup@claude-plugins-official"
     "posthog@claude-plugins-official"
     "ralphex@ralphex"
+    "modern-web-guidance@googlechrome"
 )
 
 for plugin in "${PLUGINS[@]}"; do

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -93,6 +93,27 @@ Wire into `devcontainer.json`:
 
 Mark as executable: `chmod +x init-plugins.sh`
 
+#### Bundled plugins
+
+`init-plugins.sh` registers three marketplaces and installs the following plugins:
+
+| Marketplace | Plugin | Purpose |
+|---|---|---|
+| `anthropics/claude-plugins-official` | `frontend-design` | Production-grade UI/UX scaffolding |
+| `anthropics/claude-plugins-official` | `code-review` | Multi-agent PR review |
+| `anthropics/claude-plugins-official` | `typescript-lsp` | TypeScript language-server tooling |
+| `anthropics/claude-plugins-official` | `code-simplifier` | Refactors for clarity and consistency |
+| `anthropics/claude-plugins-official` | `playwright` | Browser MCP (system chromium via `patch-playwright-mcp`) |
+| `anthropics/claude-plugins-official` | `superpowers` | Workflow skills (TDD, debugging, planning) |
+| `anthropics/claude-plugins-official` | `explanatory-output-style` | Educational output mode |
+| `anthropics/claude-plugins-official` | `claude-md-management` | Audits and updates CLAUDE.md |
+| `anthropics/claude-plugins-official` | `claude-code-setup` | Settings, permissions, automation helpers |
+| `anthropics/claude-plugins-official` | `posthog` | PostHog product-analytics & LLM-traces skills |
+| `umputun/ralphex` | `ralphex` | Autonomous plan execution |
+| `GoogleChrome/modern-web-guidance` | `modern-web-guidance` | Accessible, performant, secure modern web patterns ([docs](https://developer.chrome.com/docs/modern-web-guidance)) |
+
+To remove a plugin in your project, delete its entry from the local `init-plugins.sh` — the script is a template, not image-baked, so each consumer controls its own list.
+
 > **Why `init-plugins.sh` stays per-project but `patch-playwright-mcp` doesn't:** `init-plugins.sh` carries project-specific configuration (marketplace list, plugin list) — it's *meant* to be edited per project. The patch script has zero project-specific config and is identical across every consumer, so it's baked into the image and flows through the same daily-rebuild + `pull_policy: always` channel as the rest of the image. That boundary is the rule: project-specific config stays per-project; universal logic moves into the image.
 
 ### Sandbox-only: `.devcontainer/claude-sandbox/init-firewall.sh`


### PR DESCRIPTION
## What

Adds the [Modern Web Guidance](https://developer.chrome.com/docs/modern-web-guidance) plugin from the Google Chrome team to the shared `claude-code/.devcontainer/init-plugins.sh` template, and documents every bundled plugin in `claude-code/README.md`.

## Why

Closes #102. The plugin ships expert-vetted skills for accessible, performant, and secure modern web work (WebAuthn/CSP, LCP/long-task optimization, modernizing legacy code, etc.) — a natural fit alongside the existing `frontend-design` plugin already in the template. The README previously had no list of which plugins the template installs, leaving consumers to read the script to find out.

## Changes

- `claude-code/.devcontainer/init-plugins.sh`: append `GoogleChrome/modern-web-guidance` to `MARKETPLACES` and `modern-web-guidance@googlechrome` to `PLUGINS`.
- `claude-code/README.md`: new `#### Bundled plugins` subsection under `### Optional: .devcontainer/init-plugins.sh` listing all 12 plugins (marketplace, plugin, purpose) with the upstream Chrome docs link inline for the new entry, plus a one-line removal hint.

## Notes

- **Marketplace name is `googlechrome`, not `modern-web-guidance`.** Issue #102 flagged uncertainty here and proposed `modern-web-guidance@modern-web-guidance` based on a slug-based heuristic. Verified against the upstream `.claude-plugin/marketplace.json`, which declares `"name": "googlechrome"` — so the canonical install is `modern-web-guidance@googlechrome`, matching what developer.chrome.com says. No container required to confirm.
- **Existing consumer projects don't auto-pick this up.** `init-plugins.sh` is a per-project template, not image-baked, so each consumer's local copy needs a sync. Consumers using the `devcontainer-upstream-sync` skill will pick this up on their next audit; others can copy the two appended lines manually.
- **No CI verify-command change.** `build-claude-code.yml` only verifies image-baked binaries and the managed-settings hook — plugin installation runs at consumer `postCreateCommand`, not at image build, so there's no plugin-install verification surface in CI for any plugin (existing or new). Consistent with how `frontend-design`, `superpowers`, etc. are currently unverified at build time.
- `bash -n` and `shellcheck` both pass clean on the updated script.

## Test plan

- [ ] In a fresh `claude-code` (default) devcontainer, run `bash .devcontainer/init-plugins.sh` and confirm both `GoogleChrome/modern-web-guidance` is listed in `claude plugin marketplace list` and `modern-web-guidance` is listed in `claude plugin list`.
- [ ] Repeat in a fresh `claude-code-sandbox` container with the default firewall (`api.github.com/meta` ranges) — confirm marketplace add and plugin install both succeed without firewall changes.
- [ ] Open a fresh Claude Code session in either container and confirm at least one `web-*` skill from the plugin appears in the available-skills list.