### PR TITLE
fix(claude-code): track .mise.toml (dotfile) in upstream-sync manifest

### DIFF
--- a/claude-code/.claude/skills/devcontainer-upstream-sync/SKILL.md
+++ b/claude-code/.claude/skills/devcontainer-upstream-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Use to audit a project's .devcontainer/ and bundled .claude/skills/
 metadata:
   author: Serge Gatezh
   url: https://github.com/gatezh
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Devcontainer Upstream Sync
@@ -70,7 +70,7 @@ but don't, and includes files that shouldn't be tracked.
 | `.claude/skills/sandbox-playwright/SKILL.md` | `claude-code/.claude/skills/sandbox-playwright/SKILL.md` | framework-track |
 | `.claude/skills/devcontainer-upstream-sync/SKILL.md` | `claude-code/.claude/skills/devcontainer-upstream-sync/SKILL.md` | framework-track |
 | `.claude/settings.json` | `claude-code/.claude/settings.json` | starter-customize |
-| `mise.toml` | `claude-code/mise.toml` | starter-customize |
+| `.mise.toml` | `claude-code/mise.toml` | starter-customize |
 
 ### Bucket meanings
 
@@ -105,7 +105,7 @@ When adopting an upstream change, preserve these per-project patterns:
 5. **`init-firewall.sh` allowlist** and **`init-plugins.sh` plugin
    list** — never auto-overwrite. Surface upstream's recipe; ask
    before adopting.
-6. **`mise.toml` versions.** Versions may legitimately lead or lag
+6. **`.mise.toml` versions.** Versions may legitimately lead or lag
    upstream. Surface; ask.
 
 ## Conventions
@@ -125,11 +125,20 @@ Walk the manifest, fetch each upstream file, diff, classify, report.
 ```sh
 # Per-row commands (run for each manifest row):
 curl -sSL "https://raw.githubusercontent.com/gatezh/devcontainers/master/${UPSTREAM_PATH}" -o /tmp/upstream-sync/$(basename "${UPSTREAM_PATH}").upstream
-diff -u "${LOCAL_PATH}" /tmp/upstream-sync/$(basename "${UPSTREAM_PATH}").upstream || true
+if [ ! -e "${LOCAL_PATH}" ]; then
+  echo "LOCAL_MISSING"
+else
+  diff -u "${LOCAL_PATH}" /tmp/upstream-sync/$(basename "${UPSTREAM_PATH}").upstream || true
+fi
 ```
 
 Classification rules per row:
 
+- Local file does not exist → **local-missing**. For `framework-track`,
+  treat as drift-needs-adopt (file should exist; copy upstream). For
+  `starter-customize` or `exemplar`, surface and ask — the project may
+  legitimately not use that file (e.g. a project that pins tool
+  versions elsewhere has no `.mise.toml`).
 - Diff is empty → **clean** (or `clean (after project-name substitution)`).
 - Diff is non-empty AND row is `framework-track`:
   - If every hunk maps to a customization-preservation pattern → **intentional-customization**.
@@ -144,6 +153,7 @@ Report format (one row per manifest entry):
 ✓ .devcontainer/claude-sandbox/devcontainer.json    framework-track    clean
 ✓ .devcontainer/devcontainer.json                   framework-track    intentional-customization (Hugo extensions, hostname)
 ⚠ .devcontainer/claude-sandbox/init-firewall.sh     exemplar           template-divergence: see Workflow 2
+⚠ .mise.toml                                        starter-customize  local-missing (project may not use mise)
 ✗ .claude/skills/sandbox-playwright/SKILL.md        framework-track    drift-needs-adopt: 3 hunks
 ```
 


### PR DESCRIPTION
## What

Fixes the `devcontainer-upstream-sync` skill's sync manifest so it tracks the local mise pin file at `.mise.toml` (dotfile), matching what every downstream project actually uses.

## Why

The manifest's local-path column listed `mise.toml`, but the rest of this repo — `claude-code/README.md`, the root `README.md`, `claude-code/.devcontainer/Dockerfile`, and `claude-code/.devcontainer/devcontainer.json` — all tell consumers to put their pins at `.mise.toml`. Because the manifest looked for the wrong filename, Workflow 1 audits reported the file as missing against every consumer and silently stopped tracking drift on the only `starter-customize` row that pins runtime versions.

mise itself accepts both filenames; `mise.toml` actually has higher precedence in mise's source (`jdx/mise` `src/config/mod.rs`). The fix isn't about picking the "canonical mise filename" — it's about aligning the manifest with this repo's own documented downstream contract.

Closes #104.

## Changes

- Manifest row updated: local `mise.toml` → `.mise.toml`; upstream stays at `claude-code/mise.toml` (the template ships under that name). The existing `init-firewall.sh` row already uses an asymmetric path, so this pattern isn't new.
- Customization-preservation rule #6 (`mise.toml versions`) renamed to `.mise.toml versions` to match.
- Workflow 1 per-row commands now pre-check local existence and emit `LOCAL_MISSING` — the original `diff -u … || true` swallowed `diff`'s "couldn't open file" exit code (2), conflating it with "files differ".
- New classification rule: **local-missing**, with bucket-aware handling — `framework-track` → drift-needs-adopt; `starter-customize` / `exemplar` → surface and ask (a project may legitimately not use `.mise.toml`).
- Report-format example updated with a `local-missing` row.
- Skill `version: 1.0.0` → `1.1.0` (minor — additive classification). Consumers pick this up via Workflow 4 self-update on their next audit.

## Notes

Reviewers may want to verify the manifest's asymmetric path doesn't surprise the diff workflow. It doesn't — `diff -u "$LOCAL_PATH" "/tmp/.../$(basename $UPSTREAM_PATH).upstream"` is filename-agnostic; it operates on file contents.