### PR TITLE
feat(claude-code): bundle claude-seo plugin in init-plugins

### DIFF
--- a/claude-code/.devcontainer/init-plugins.sh
+++ b/claude-code/.devcontainer/init-plugins.sh
@@ -23,6 +23,7 @@ MARKETPLACES=(
     "anthropics/claude-plugins-official"
     "umputun/ralphex"
     "GoogleChrome/modern-web-guidance"
+    "AgriciDaniel/claude-seo"
 )
 
 for marketplace in "${MARKETPLACES[@]}"; do
@@ -48,6 +49,7 @@ PLUGINS=(
     "posthog@claude-plugins-official"
     "ralphex@ralphex"
     "modern-web-guidance@googlechrome"
+    "claude-seo@agricidaniel-claude-seo"
 )
 
 for plugin in "${PLUGINS[@]}"; do

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -95,7 +95,7 @@ Mark as executable: `chmod +x init-plugins.sh`
 
 #### Bundled plugins
 
-`init-plugins.sh` registers three marketplaces and installs the following plugins:
+`init-plugins.sh` registers four marketplaces and installs the following plugins:
 
 | Marketplace | Plugin | Purpose |
 |---|---|---|
@@ -111,6 +111,7 @@ Mark as executable: `chmod +x init-plugins.sh`
 | `anthropics/claude-plugins-official` | `posthog` | PostHog product-analytics & LLM-traces skills |
 | `umputun/ralphex` | `ralphex` | Autonomous plan execution |
 | `GoogleChrome/modern-web-guidance` | `modern-web-guidance` | Accessible, performant, secure modern web patterns ([docs](https://developer.chrome.com/docs/modern-web-guidance)) |
+| `AgriciDaniel/claude-seo` | `claude-seo` | SEO analysis toolkit — technical SEO, schema, E-E-A-T, GEO/AEO, Google APIs ([repo](https://github.com/AgriciDaniel/claude-seo)) |
 
 To remove a plugin in your project, delete its entry from the local `init-plugins.sh` — the script is a template, not image-baked, so each consumer controls its own list.
 


### PR DESCRIPTION
## What
Adds the `claude-seo` plugin to the Claude Code devcontainer's bundled plugin set in `init-plugins.sh`.

## Why
`claude-seo` provides an SEO analysis toolkit (technical SEO, schema, E-E-A-T, GEO/AEO, Google APIs) that's useful out-of-the-box for content/web projects using this devcontainer. Bundling it means consumers get it on container creation without manual marketplace setup.

## Changes
- `init-plugins.sh`: register the `AgriciDaniel/claude-seo` marketplace and install `claude-seo`
  - Plugin is referenced as `claude-seo@agricidaniel-claude-seo` — the marketplace name is the `name` declared in the upstream `marketplace.json`, **not** a value derived from the `owner/repo` add reference
- `README.md`: bump "three marketplaces" → "four" and add the `claude-seo` row to the bundled-plugins table

## Notes
- The install loop swallows failures (`|| ⚠ Failed`), so a wrong marketplace name would fail *silently* at container creation — verified the `agricidaniel-claude-seo` name against the upstream manifest to avoid that.
- No CI job shellchecks `init-plugins.sh`; validated locally with `bash -n` (syntax OK) and `shellcheck` (clean).