### PR TITLE
fix(claude-code): install openssh-client for SSH-format commit signing

### DIFF
--- a/claude-code/.devcontainer/Dockerfile
+++ b/claude-code/.devcontainer/Dockerfile
@@ -55,6 +55,13 @@ ARG GIT_DELTA_VERSION=0.18.2
 # - git: version control
 # - jq: JSON processing (firewall script, onboarding patch)
 # - less: pager for git delta output
+# - openssh-client: provides ssh-keygen, needed for SSH-format commit signing
+#   (gpg.format=ssh + commit.gpgsign=true, copied in via VS Code's
+#   dev.containers.copyGitConfig); also restores ssh/ssh-add. git only
+#   *Recommends* it, so --no-install-recommends drops it unless listed here.
+#   Hard-depends on libfido2, so FIDO2 hardware keys (YubiKey sk-ssh-ed25519)
+#   sign too. Must be in base: the sandbox firewall blocks deb.debian.org, so
+#   it can't be added at runtime (same reasoning as chromium). See issue #110.
 # - sudo: privilege escalation for firewall setup
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
@@ -67,6 +74,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   git \
   jq \
   less \
+  openssh-client \
   sudo
 
 # npm global directory with proper permissions for node user

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -17,7 +17,7 @@ Projects consume these pre-built images and control their own tool versions via 
 |-------|------|-----|
 | OS | `node:24-trixie-slim` + system packages | Node is needed during the build (Playwright, npm globals) |
 | Shell | Fish, Starship, fzf | Built-in syntax highlighting, autosuggestions, completions |
-| Tools | git-delta, gh CLI, jq, nano, vim, wget, unzip, less, man-db, procps | Standard dev utilities |
+| Tools | git-delta, gh CLI, jq, nano, vim, wget, unzip, less, man-db, procps, openssh-client | Standard dev utilities (`openssh-client` provides `ssh`/`ssh-keygen` — enables SSH-format commit signing) |
 | Mise | The tool manager itself (not the tools) | Projects run `mise install` at container creation for their tool versions |
 | rtk, ralphex | Always-latest from GitHub Releases | Dev infrastructure (like Claude Code) — no version pinning needed in projects |
 | Claude Code | npm global install | npm avoids rate limiting that affects the native installer in parallel CI builds |


### PR DESCRIPTION
## Summary

The `claude-code` base image ships without `openssh-client`, so `ssh-keygen` is
absent and any container using SSH-format commit signing (`gpg.format=ssh` +
`commit.gpgsign=true`) fails to commit with
`error: cannot run ssh-keygen: No such file or directory`. This is commonly
triggered by VS Code's `dev.containers.copyGitConfig`, which copies the host
signing config into the container.

**Root cause:** the shared `base` apt block uses `--no-install-recommends`, which
drops git's *Recommends* on `ssh-client` (provided by `openssh-client`).

## Fix

Add `openssh-client` to the shared `base` stage apt block, so both the `default`
and `sandbox` targets get `ssh-keygen`/`ssh`/`ssh-add` in one place.

- **Must be in `base`:** the sandbox firewall blocks `deb.debian.org`, so it
  can't be apt-installed at runtime (same reasoning already documented for
  `chromium`).
- `openssh-client` hard-**Depends** on `libfido2-1`, so FIDO2 hardware keys
  (YubiKey `sk-ssh-ed25519`) sign too — this holds even under
  `--no-install-recommends`.

## Verification

- Confirmed against packages.debian.org (trixie): `openssh-client` provides
  `/usr/bin/ssh-keygen`, `/usr/bin/ssh`, `/usr/bin/ssh-add`; `libfido2-1 (>= 1.8.0)`
  is a hard `Depends`, not a Recommends.
- Hadolint clean against the project's `.hadolint.yaml`.

Closes #110
