### PR TITLE
fix(ralphex-fe): rebuild daily for latest ralphex/rtk + repair update workflow

### DIFF
--- a/.github/workflows/build-ralphex-fe.yml
+++ b/.github/workflows/build-ralphex-fe.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - 'ralphex-fe/Dockerfile'
       - 'ralphex-fe/*.sh'
+  schedule:
+    # Daily rebuild to bake in the latest ralphex and rtk releases, which the
+    # Dockerfile pulls from GitHub "latest" at build time. Offset from
+    # build-claude-code.yml's 11:13 to avoid hitting the GitHub API at the same minute.
+    - cron: '41 11 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-and-build-ralphex-fe.yml
+++ b/.github/workflows/update-and-build-ralphex-fe.yml
@@ -11,10 +11,6 @@ on:
         description: 'New Hugo version (e.g., 0.155.3). Leave empty to keep current.'
         required: false
         type: string
-      ralphex_version:
-        description: 'Ralphex version / Docker image tag (e.g., 0.11.0). Leave empty to keep current.'
-        required: false
-        type: string
       update_only:
         description: 'Only update Dockerfile without building image'
         required: false
@@ -39,7 +35,6 @@ jobs:
       versions_updated: ${{ steps.update.outputs.updated }}
       bun_version: ${{ steps.update.outputs.bun_version }}
       hugo_version: ${{ steps.update.outputs.hugo_version }}
-      ralphex_version: ${{ steps.update.outputs.ralphex_version }}
 
     steps:
       - name: Checkout repository
@@ -52,49 +47,41 @@ jobs:
         env:
           INPUT_BUN_VERSION: ${{ inputs.bun_version }}
           INPUT_HUGO_VERSION: ${{ inputs.hugo_version }}
-          INPUT_RALPHEX_VERSION: ${{ inputs.ralphex_version }}
         run: |
           # Read current versions
           CURRENT_BUN=$(grep '^ARG BUN_VERSION=' "${{ env.DOCKERFILE_PATH }}" | cut -d'=' -f2)
           CURRENT_HUGO=$(grep '^ARG HUGO_VERSION=' "${{ env.DOCKERFILE_PATH }}" | cut -d'=' -f2)
-          CURRENT_RALPHEX=$(grep '^ARG RALPHEX_VERSION=' "${{ env.DOCKERFILE_PATH }}" | cut -d'=' -f2)
 
-          if [ -z "$CURRENT_BUN" ] || [ -z "$CURRENT_HUGO" ] || [ -z "$CURRENT_RALPHEX" ]; then
+          if [ -z "$CURRENT_BUN" ] || [ -z "$CURRENT_HUGO" ]; then
             echo "Error: Failed to extract current version(s) from Dockerfile"
             echo "  Bun: ${CURRENT_BUN:-<empty>}"
             echo "  Hugo: ${CURRENT_HUGO:-<empty>}"
-            echo "  Ralphex: ${CURRENT_RALPHEX:-<empty>}"
             exit 1
           fi
 
           echo "Current versions:"
           echo "  Bun: $CURRENT_BUN"
           echo "  Hugo: $CURRENT_HUGO"
-          echo "  Ralphex: $CURRENT_RALPHEX"
 
           # Use input values or fall back to current Dockerfile values
           NEW_BUN=${INPUT_BUN_VERSION:-$CURRENT_BUN}
           NEW_HUGO=${INPUT_HUGO_VERSION:-$CURRENT_HUGO}
-          NEW_RALPHEX=${INPUT_RALPHEX_VERSION:-$CURRENT_RALPHEX}
 
           echo ""
           echo "Target versions:"
           echo "  Bun: $NEW_BUN"
           echo "  Hugo: $NEW_HUGO"
-          echo "  Ralphex: $NEW_RALPHEX"
 
           # Update versions in Dockerfile (GNU sed syntax for Linux)
           # Use | as delimiter to avoid breakage if version strings contain /
           sed -i "s|^ARG BUN_VERSION=.*|ARG BUN_VERSION=$NEW_BUN|" "${{ env.DOCKERFILE_PATH }}"
           sed -i "s|^ARG HUGO_VERSION=.*|ARG HUGO_VERSION=$NEW_HUGO|" "${{ env.DOCKERFILE_PATH }}"
-          sed -i "s|^ARG RALPHEX_VERSION=.*|ARG RALPHEX_VERSION=$NEW_RALPHEX|" "${{ env.DOCKERFILE_PATH }}"
 
           # Verify changes
           echo ""
           echo "Updated versions in Dockerfile:"
           grep '^ARG BUN_VERSION=' "${{ env.DOCKERFILE_PATH }}"
           grep '^ARG HUGO_VERSION=' "${{ env.DOCKERFILE_PATH }}"
-          grep '^ARG RALPHEX_VERSION=' "${{ env.DOCKERFILE_PATH }}"
 
           # Check if anything changed
           if git diff --quiet "${{ env.DOCKERFILE_PATH }}"; then
@@ -108,7 +95,6 @@ jobs:
           {
             echo "bun_version=$NEW_BUN"
             echo "hugo_version=$NEW_HUGO"
-            echo "ralphex_version=$NEW_RALPHEX"
           } >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
@@ -116,7 +102,6 @@ jobs:
         env:
           BUN_VERSION: ${{ steps.update.outputs.bun_version }}
           HUGO_VERSION: ${{ steps.update.outputs.hugo_version }}
-          RALPHEX_VERSION: ${{ steps.update.outputs.ralphex_version }}
           GITHUB_ACTOR: ${{ github.actor }}
           ACTOR_ID: ${{ github.actor_id }}
         run: |
@@ -127,7 +112,7 @@ jobs:
 
           # [skip ci] prevents build-ralphex-fe.yml from triggering a duplicate build
           git commit \
-            -m "chore(ralphex-fe): update versions to Bun ${BUN_VERSION}, Hugo ${HUGO_VERSION}, Ralphex ${RALPHEX_VERSION} [skip ci]" \
+            -m "chore(ralphex-fe): update versions to Bun ${BUN_VERSION}, Hugo ${HUGO_VERSION} [skip ci]" \
             -m "Updated via GitHub Actions workflow dispatch." \
             -m "Co-Authored-By: ${GITHUB_ACTOR} <${ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com>"
 
@@ -152,7 +137,7 @@ jobs:
       image-name: devcontainers/ralphex-fe
       context: ralphex-fe
       dockerfile: ralphex-fe/Dockerfile
-      version-tag: bun${{ needs.update-dockerfile.outputs.bun_version }}-hugo${{ needs.update-dockerfile.outputs.hugo_version }}-ralphex${{ needs.update-dockerfile.outputs.ralphex_version }}
+      version-tag: bun${{ needs.update-dockerfile.outputs.bun_version }}-hugo${{ needs.update-dockerfile.outputs.hugo_version }}
       verify-command: 'bun --version && hugo version'
       extra-verify-script: |
         chromium --no-sandbox --version && \


### PR DESCRIPTION
## What
Adds a daily scheduled rebuild to the `ralphex-fe` image and repairs the now-dead manual version-bump workflow.

## Why
`ralphex-fe` was expected to rebuild daily — like `claude-code` — so it picks up the latest `ralphex` and `rtk` releases (both pulled from GitHub `releases/latest` at build time). But `build-ralphex-fe.yml` never had a `schedule:` trigger. Nothing broke; the cron was simply never wired up, so the published `ralphex-fe:latest` had been frozen since its last Dockerfile change (2026-04-14, ~2 months stale).

While in here, `update-and-build-ralphex-fe.yml` was found to be silently broken: it greps for `ARG RALPHEX_VERSION`, which the Dockerfile dropped when `ralphex` switched to dynamic `latest` pulling. Every dispatch failed at the extract step (`exit 1`).

For context, the RTK v0.36.0 GDPR-consent-hang fix (the prior "rtk broke the build" episode) was already present in `ralphex-fe/init-docker.sh` — this PR does not touch it.

## Changes
- **`build-ralphex-fe.yml`**: add `schedule: cron '41 11 * * *'` (mirrors `build-claude-code.yml`; offset from its 11:13 to avoid hitting the GitHub API the same minute).
- **`update-and-build-ralphex-fe.yml`**: remove the obsolete `ralphex_version` input/output/env/sed/grep, and realign the version-tag to `bun<v>-hugo<v>` to match `build-ralphex-fe.yml`. The Bun/Hugo manual-bump path is kept intact.

## Notes
- Scheduled workflows only fire from the **default branch**, so the daily rebuild begins after this merges to `master`.
- Both workflows pass `actionlint` locally (the same check CI runs on `.github/workflows/**`).